### PR TITLE
Check Group membership using group dn instead base dn with OpenLDAP

### DIFF
--- a/class.ldap.php
+++ b/class.ldap.php
@@ -240,8 +240,8 @@ class Ldap {
 			$this->write_log("[check_ldap_group_membership]> OpenLDAP Mode");
 			// Do a member search for the user (OpenLDAP)
 			$search_filter = "(&(objectclass=$group_class)($group_cn))"; 
-			$this->write_log("[check_ldap_group_membership]> @ldap_search(\$this->cnx,'$base_dn', '$search_filter','$member_attr'");
-			$search = ldap_search($this->cnx, $base_dn, $search_filter,array($member_attr),0,0,5); //search for group
+			$this->write_log("[check_ldap_group_membership]> @ldap_search(\$this->cnx,'$group_dn', '$search_filter','$member_attr'");
+			$search = ldap_search($this->cnx, $group_dn, $search_filter,array($member_attr),0,0,5); //search for group
 			if($search){
 				$entries = ldap_get_entries($this->cnx,$search); //get group
 				$this->write_log("[ldap_get_entries]>". serialize($entries));


### PR DESCRIPTION
refs: https://github.com/VSLCatena/ldap_login/issues/3

It should search member_attr using group_dn, but it searched using **base_dn** .
I fix it and it can search members of group correctly now.