### PR TITLE
Code cannot use the value of a translated html button

### DIFF
--- a/admin/group_management.php
+++ b/admin/group_management.php
@@ -243,9 +243,9 @@ function sync_ldap(){
 
 
 // Save LDAP configuration when submitted
-if (isset($_POST['sync_action'])){
+if (isset($_POST['sync_action_submit']) || isset($_POST['sync_action_refresh'])){
 	$ldap->ldap_conn();
-	if($_POST['sync_action'] =='Submit') {
+	if(isset($_POST['sync_action_submit'])) {
 	
 		//activate groups.
 		if(!($ld_sync_data==null)){
@@ -300,7 +300,7 @@ if (isset($_POST['sync_action'])){
 	}
 
 	//Refresh button on page.
-	if ($_POST['sync_action'] =='Refresh'){ 
+	if (isset($_POST['sync_action_refresh'])){
 		$ld_sync_data = $ldap->ldap_get_groups($ldap->config['ld_group_basedn']);
 		$ldap->config['ld_sync_data']=serialize($ld_sync_data);
 		$ldap->save_config();

--- a/admin/group_management.php
+++ b/admin/group_management.php
@@ -80,7 +80,7 @@ function sync_create_group($groups){
 				if ($count != 0)
 				{
 					$err=True;
-					$page['errors'][] = l10n('This name for the group ('. $tmp_group . ') already exist.');
+					$page['errors'][] = l10n('This name for the group (%s) already exist.', $tmp_group);
 				}
 				#delete sync / reverse sync
 			}

--- a/admin/group_management.tpl
+++ b/admin/group_management.tpl
@@ -69,8 +69,8 @@ td.content {
 		
 		<p style="text-align: left !important;" >
 		<i>{'Press Submit for the above actions. Only press "Refresh" to get new data via LDAP. Use with care.'|@translate}</i><br /><br />
-			<input style="margin-left:10px; margin-right:10px;" type="submit" value="{'Submit'|@translate}" name="sync_action" />
-			<input style="margin-left:10px; margin-right:10px;" type="submit" value="{'Refresh'|@translate}" name="sync_action" />
+			<input style="margin-left:10px; margin-right:10px;" type="submit" value="{'Submit'|@translate}" name="sync_action_submit" />
+			<input style="margin-left:10px; margin-right:10px;" type="submit" value="{'Refresh'|@translate}" name="sync_action_refresh" />
 		</p>
 		<br />
 		<fieldset class="mainConf">


### PR DESCRIPTION
When a TPL uses "<input ... value="{'Submit'|@translate}" name="sync_action" ... >"
then the code cannot suppose that $_POST['sync_action'] will be 'Submit'
It will be its translation.