### PR TITLE
authenticate against LDAP before group query

### DIFF
--- a/class.ldap.php
+++ b/class.ldap.php
@@ -482,8 +482,10 @@ class Ldap {
 
 	public function ldap_get_groups($ld_prim_group){
 		$master = array();
+		if(!$this->make_ldap_bind_as($this->cnx,$this->config['ld_binddn'],$this->config['ld_bindpw'])){
+			return false;
+		}
 		function ldap_get_group_data($group,$con,$depth,$path,$parent) {
-			
 			if ($parentData=ldap_read($con,$group, "(|(objectclass=person)(objectclass=groupOfNames))", array('cn','dn','member','objectclass'))){
 				$entry = ldap_get_entries($con, $parentData); #get all info from query
 				if($entry['count']>0){ //only if object person / group, will alway return 1 array!

--- a/main.inc.php
+++ b/main.inc.php
@@ -229,7 +229,14 @@ function login($success, $username, $password, $remember_me){
 				// retrieve LDAP e-mail address and create a new user
 				$mail = $obj->ldap_get_email($user_dn);
 			}
-			$new_id = register_user($username,random_password(8),$mail);
+			$errors=[];
+			$new_id = register_user($username,random_password(8),$mail,true,$errors);
+			if(count($errors) > 0) {
+				foreach ($errors as &$e){
+					$obj->write_log("[login]> ".$e, 'ERROR');
+				}
+				return false;
+			}
 			// Login user
 			log_user($new_id, False);
 			trigger_notify('login_success', stripslashes($username));


### PR DESCRIPTION
Previously, the group query did not authenticate. By that, on a secured LDAP no groups where returned.

The other fix is about logging the errors when a user tries to log in via LDAP for the first time. By that, errors like duplicated e-mail addresses can be debugged more easily.