### PR TITLE
unsecaping bind passwords so special characters work

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -56,10 +56,8 @@ if (isset($_POST['save']) or isset($_POST['savetest'])){
 	$me->config['ld_group_admin']   = $_POST['LD_GROUP_ADMIN'];
 	$me->config['ld_group_webmaster']   = $_POST['LD_GROUP_WEBMASTER'];
 	
-	$me->config['ld_binddn'] = $_POST['LD_BINDDN']; //reverted, did not work
-	//$me->config['ld_binddn'] = ldap_escape($_POST['LD_BINDDN'], '', LDAP_ESCAPE_DN);
-	$me->config['ld_bindpw'] =  $_POST['LD_BINDPW']; //reverted, did not work
-	//$me->config['ld_bindpw'] =  ldap_escape($_POST['LD_BINDPW'], '', LDAP_ESCAPE_DN);
+	$me->config['ld_binddn'] = $_POST['LD_BINDDN'];
+	$me->config['ld_bindpw'] = stripslashes($_POST['LD_BINDPW']);
 
 	$me->config['ld_debug'] = $_POST['LD_DEBUG'];
 	$me->config['ld_debug_clearupdate'] = $_POST['LD_DEBUG_CLEARUPDATE'];

--- a/class.ldap.php
+++ b/class.ldap.php
@@ -270,7 +270,7 @@ class Ldap {
 		$this->write_log("[function]> ldap_bind_as");
 		$this->write_log("[ldap_bind_as]> ".$user);
 		
-		if($this->make_ldap_bind_as($this->cnx,$user,$user_passwd)){
+		if($this->make_ldap_bind_as($this->cnx,$user,stripslashes($user_passwd))){
 			$this->write_log("[ldap_bind_as]> Bind was successfull");
 			return true;
 		}


### PR DESCRIPTION
Unescaping `\` and `'`via `stripslashes` to make passwords with special characters work (as advertised by its [documentation](https://www.w3schools.com/php/func_string_stripslashes.asp): *This function can be used to clean up data retrieved from a database or from an HTML form.*)

Should take care of #22.

Fyi: `ldap_escape`is [only valid for escaping DNs or filters](https://www.php.net/manual/en/function.ldap-escape.php), passwords be used as they are.